### PR TITLE
Revert "Fixed #39 Close plots after displaying them in Streamlit for resource release"

### DIFF
--- a/app/components/EDA/monthly_sales.py
+++ b/app/components/EDA/monthly_sales.py
@@ -64,7 +64,6 @@ def __plot(df):
 
     # Display plot in Streamlit
     st.pyplot(plt.gcf())
-    plt.close()
 
 
 def __plot_line_chart(ax1, df_total_sales):

--- a/app/components/EDA/order_count_by_state.py
+++ b/app/components/EDA/order_count_by_state.py
@@ -18,7 +18,6 @@ def display_order_count_by_state():
     # streamlit
     st.subheader("Order Count by Customer State")
     st.pyplot(plt.gcf())
-    plt.close()
     cap_order_count_by_customer_state()
 
 

--- a/app/components/EDA/order_date_by_states.py
+++ b/app/components/EDA/order_date_by_states.py
@@ -56,7 +56,6 @@ def __plot_order_date(df_orders):
     plt.legend(title="Customer State", bbox_to_anchor=(1.05, 1), loc="upper left")
 
     st.pyplot(plt.gcf())
-    plt.close()
 
 
 def __plot_per_weekday(df_orders):
@@ -81,7 +80,6 @@ def __plot_per_weekday(df_orders):
     plt.title("Orders per Weekday by Customer State")
 
     st.pyplot(plt.gcf())
-    plt.close()
 
 
 def __plot_order_per_time_of_day(df_orders):
@@ -112,9 +110,7 @@ def __plot_order_per_time_of_day(df_orders):
     plt.xlabel("Time of Day")
     plt.ylabel("Count")
     plt.xticks(rotation=45)
-    
     st.pyplot(plt.gcf())
-    plt.close()
 
     time_of_day_df = pd.DataFrame(
         {

--- a/app/components/EDA/ordered_product_category.py
+++ b/app/components/EDA/ordered_product_category.py
@@ -25,10 +25,7 @@ def display_ordered_product_category(state=""):
     # Display using streamlit
     st.title(f"Top 10 Ordered Product Categories  {'in ' + state if state else ''}")
     st.write(f"There are {category_num} categories in total.")
-    
     st.pyplot(plt.gcf())
-    plt.close()
-
     cap_top10_ordered_product_categories()
     st.write("Other categories:")
     st.dataframe(counts, height=200)

--- a/app/components/EDA/payment_amount.py
+++ b/app/components/EDA/payment_amount.py
@@ -48,8 +48,7 @@ def __display_histogram(df):
     plt.ylabel("Frequency")
     plt.title("Payment Value Distribution")
 
-    st.pyplot(plt.gcf())
-    plt.close()
+    st.pyplot(plt)
 
 
 def __display_box_plot(df):
@@ -62,4 +61,3 @@ def __display_box_plot(df):
 
     # Display the box plot
     st.pyplot(plt.gcf())
-    plt.close()

--- a/app/components/EDA/payment_type.py
+++ b/app/components/EDA/payment_type.py
@@ -47,10 +47,7 @@ def __plot_pie_chart(df_order_payments):
     df_payment_type = df_order_payments["payment_type"].value_counts()
     plt.figure(figsize=(8, 4))
     plt.pie(df_payment_type, labels=df_payment_type.index, autopct="%1.1f%%")
-
     st.pyplot(plt.gcf())
-    plt.close()
-
     with st.container(border=True):
         st.markdown(
             """
@@ -89,9 +86,7 @@ def __plot_line_chart(df):
     plt.xlabel("Month")
     plt.ylabel("Count")
     plt.legend(title="Payment Type")
-
     st.pyplot(plt.gcf())
-    plt.close()
 
 
 def __show_credit_card_metrics(df):
@@ -139,6 +134,4 @@ def __plot_box_plot(df):
     plt.yscale("log")
     plt.xlabel("Payment Type")
     plt.ylabel("Price (Log)")
-
     st.pyplot(plt.gcf())
-    plt.close()

--- a/app/components/EDA/review_score.py
+++ b/app/components/EDA/review_score.py
@@ -80,7 +80,6 @@ def __plot_bar_chart(df, product_category):
         f'Distribution of Review Scores {"for " + product_category if product_category else ""}'
     )
     st.pyplot(plt.gcf())
-    plt.close()
 
 
 def __plot_bar_chart_order_count_by_product_category(df):
@@ -108,4 +107,3 @@ def __plot_bar_chart_order_count_by_product_category(df):
 
     # streamlit
     st.pyplot(plt.gcf())
-    plt.close()

--- a/app/components/EDA/total_order.py
+++ b/app/components/EDA/total_order.py
@@ -67,7 +67,6 @@ def __plot_per_weekday(df_orders):
     for i, v in enumerate(df_week_counts.values):
         plt.text(i, v + offset_value, str(v), ha="center", va="bottom")
     st.pyplot(plt.gcf())
-    plt.close()
 
 
 def __plot_order_per_time_of_day(df_orders):
@@ -103,7 +102,6 @@ def __plot_order_per_time_of_day(df_orders):
     for i, v in enumerate(df_counts.values):
         plt.text(i, v + offset_value, str(v), ha="center", va="bottom")
     st.pyplot(plt.gcf())
-    plt.close()
 
     time_of_day_df = pd.DataFrame(
         {

--- a/app/components/EDA/total_sales_by_state.py
+++ b/app/components/EDA/total_sales_by_state.py
@@ -47,6 +47,4 @@ def __plot(total_sales_by_state):
 
     formatter = FuncFormatter(millions_formatter)
     ax.yaxis.set_major_formatter(formatter)
-    
     st.pyplot(plt.gcf())
-    plt.close()

--- a/app/components/RFM/frequency.py
+++ b/app/components/RFM/frequency.py
@@ -48,5 +48,4 @@ def __display_histogram(df):
     plt.xlabel("Frequency")
     plt.title("Frequency Distribution")
 
-    st.pyplot(plt.gcf())
-    plt.close()
+    st.pyplot(plt)

--- a/app/components/RFM/recency.py
+++ b/app/components/RFM/recency.py
@@ -66,5 +66,4 @@ def __display_histogram(df):
     plt.ylabel("Frequency")
     plt.title("Recency Distribution")
 
-    st.pyplot(plt.gcf())
-    plt.close()
+    st.pyplot(plt)


### PR DESCRIPTION
Reverts Yuki-bach/marketing#48

The PR worked in my local environment, but it didn't work in streamlit cloud. 
so I revert the PR

## error
> ValueError: Image size of 7612x10076661 pixels is too large. It must be less than 2^16 in each direction.
/mount/src/marketing/app/components/EDA/payment_type.py:94: UserWarning: Could not infer format, so each element will be parsed individually, falling back to `dateutil`. To ensure parsing is consistent and as-expected, please specify a format.
  plt.close()